### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,28 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  // Cria um objeto de erro público com a causa do erro
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  // Retorna uma resposta de erro 500 com o objeto de erro público
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler, // Manipulador para métodos não permitidos
+    onError: onErrorHandler, // Manipulador para erros internos do servidor
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors.js";
 
 //Função assíncrona para executar uma consulta no banco de dados.
 async function query(queryObject) {
@@ -8,12 +9,13 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    // Exibe o erro no terminal
-    console.log("\n Erro dentro do catch do database.js:");
-    console.error(error);
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com Banco ou na Query.",
+      cause: error,
+    });
 
     // Lança a exceção novamente para ser tratada pelo chamador da função
-    throw error;
+    throw serviceErrorObject;
   } finally {
     // Certifique-se de fechar a conexão ao final, independentemente do sucesso ou falha
     await client?.end();

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,13 +1,57 @@
 // Classe de erro para erros internos do servidor
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     // Chama o construtor da classe pai (Error) com uma mensagem padrão e a causa do erro
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "InternalServerError"; // Nome do erro
     this.action = "Entre em contato com o suporte"; // Ação recomendada ao usuário
-    this.statusCode = 500; // Código de status HTTP
+    this.statusCode = statusCode || 500; // Código de status HTTP
+  }
+
+  // Converte o erro para um formato JSON
+  toJSON() {
+    return {
+      name: this.name, // Nome do erro
+      message: this.message, // Mensagem do erro
+      action: this.action, // Ação recomendada ao usuário
+      status_code: this.statusCode, // Código de status HTTP
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    // Chama o construtor da classe pai (Error) com uma mensagem padrão e a causa do erro
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError"; // Nome do erro
+    this.action = "Verifique se o serviço está disponível."; // Ação recomendada ao usuário
+    this.statusCode = 503; // Código de status HTTP
+  }
+
+  // Converte o erro para um formato JSON
+  toJSON() {
+    return {
+      name: this.name, // Nome do erro
+      message: this.message, // Mensagem do erro
+      action: this.action, // Ação recomendada ao usuário
+      status_code: this.statusCode, // Código de status HTTP
+    };
+  }
+}
+
+// Classe de erro para erros internos do servidor
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    // Chama o construtor da classe pai (Error) com uma mensagem padrão e a causa do erro
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError"; // Nome do erro
+    this.action =
+      "Verifique se o método HTTP enviado é valido para este endpoint."; // Ação recomendada ao usuário
+    this.statusCode = 405; // Código de status HTTP
   }
 
   // Converte o erro para um formato JSON

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv-expand": "11.0.6",
         "micromatch": "^4.0.8",
         "next": "14.2.6",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2089,6 +2090,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8547,6 +8554,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9585,6 +9605,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv-expand": "11.0.6",
     "micromatch": "^4.0.8",
     "next": "14.2.6",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,54 +1,68 @@
 // Controller
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
+import controller from "infra/controller.js";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method "${request.method}" not allowed`,
-    });
-  }
+// Cria uma instância do roteador
+const router = createRouter();
 
+// Define o manipulador para o método GET e para o método POST
+router.get(getHandler);
+router.post(postHandler);
+
+// Exporta o roteador com os manipuladores de erro personalizados
+export default router.handler(controller.errorHandlers);
+
+// Manipulador para métodos não permitidos
+
+const defaultMigrationOptions = {
+  dryRun: true,
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function getHandler(request, response) {
   let dbClient;
 
   try {
     // Abre a conexão com o banco de dados
     dbClient = await database.getNewClient();
 
-    const defaultMigrationOptions = {
-      dbClient: dbClient,
-      dryRun: true,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
+    const pendingMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+    });
+    //Inclui a versão na resposta
+    return response.status(200).json(pendingMigrations);
+  } finally {
+    // Fecha a conexão com o banco de dados
+    await dbClient.end();
+  }
+}
 
-    if (request.method === "GET") {
-      const pendingMigrations = await migrationRunner(defaultMigrationOptions);
+async function postHandler(request, response) {
+  let dbClient;
 
-      //Inclui a versão na resposta
-      return response.status(200).json(pendingMigrations);
+  try {
+    // Abre a conexão com o banco de dados
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+      dryRun: false,
+    });
+
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
     }
 
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationOptions,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-
-      //Inclui a versão na resposta
-      return response.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
+    //Inclui a versão na resposta
+    return response.status(200).json(migratedMigrations);
   } finally {
     // Fecha a conexão com o banco de dados
     await dbClient.end();

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,64 +1,58 @@
 // Controller
+import { createRouter } from "next-connect";
 import database from "infra/database";
-import { InternalServerError } from "infra/errors";
+import controller from "infra/controller.js";
 
-async function status(request, response) {
-  try {
-    const updateAt = new Date().toISOString();
+// Cria uma instância do roteador
+const router = createRouter();
 
-    // Consulta o banco de dados para obter a versão do servidor
-    const databaseVersionResult = await database.query("SHOW server_version;");
+// Define o manipulador para o método GET
+router.get(getHandler);
 
-    // Extrai a versão do servidor do resultado da consulta
-    const databaseVersionValue =
-      await databaseVersionResult.rows[0].server_version;
+// Exporta o roteador com os manipuladores de erro personalizados
+export default router.handler(controller.errorHandlers);
 
-    // Consulta o banco de dados para obter o número máximo de conexões
-    const databaseMaxConnectionsResult = await database.query(
-      "SHOW max_connections;",
-    );
+async function getHandler(request, response) {
+  const updateAt = new Date().toISOString();
 
-    // Extrai o número máximo de conexões do resultado da consulta
-    const databaseMaxConnectionsValue =
-      databaseMaxConnectionsResult.rows[0].max_connections;
+  // Consulta o banco de dados para obter a versão do servidor
+  const databaseVersionResult = await database.query("SHOW server_version;");
 
-    // Obtém o nome do banco de dados a partir das variáveis de ambiente
-    const databaseName = process.env.POSTGRES_DB;
+  // Extrai a versão do servidor do resultado da consulta
+  const databaseVersionValue =
+    await databaseVersionResult.rows[0].server_version;
 
-    // Consulta o banco de dados para obter o número de conexões abertas para esse banco de dados
-    const databaseOpenedConnectionsResult = await database.query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    });
+  // Consulta o banco de dados para obter o número máximo de conexões
+  const databaseMaxConnectionsResult = await database.query(
+    "SHOW max_connections;",
+  );
 
-    // Extrai o número de conexões abertas do resultado da consulta
-    const databaseOpenedConnectionsValue =
-      databaseOpenedConnectionsResult.rows[0].count;
+  // Extrai o número máximo de conexões do resultado da consulta
+  const databaseMaxConnectionsValue =
+    databaseMaxConnectionsResult.rows[0].max_connections;
 
-    //Inclui a versão na resposta
-    response.status(200).json({
-      updated_at: updateAt, // Data de atualização
-      dependencies: {
-        database: {
-          version: databaseVersionValue, // Versão do banco de dados
-          max_connections: parseInt(databaseMaxConnectionsValue), // Máximo de conexões permitidas
-          opened_connections: databaseOpenedConnectionsValue, // Conexões abertas atualmente
-        },
+  // Obtém o nome do banco de dados a partir das variáveis de ambiente
+  const databaseName = process.env.POSTGRES_DB;
+
+  // Consulta o banco de dados para obter o número de conexões abertas para esse banco de dados
+  const databaseOpenedConnectionsResult = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+
+  // Extrai o número de conexões abertas do resultado da consulta
+  const databaseOpenedConnectionsValue =
+    databaseOpenedConnectionsResult.rows[0].count;
+
+  //Inclui a versão na resposta
+  response.status(200).json({
+    updated_at: updateAt, // Data de atualização
+    dependencies: {
+      database: {
+        version: databaseVersionValue, // Versão do banco de dados
+        max_connections: parseInt(databaseMaxConnectionsValue), // Máximo de conexões permitidas
+        opened_connections: databaseOpenedConnectionsValue, // Conexões abertas atualmente
       },
-    });
-  } catch (error) {
-    // Cria um objeto de erro público com a causa do erro
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    // Loga o erro no console
-    console.log("\n Erro dentro do catch do controller:");
-    console.error(publicErrorObject);
-
-    // Retorna uma resposta de erro 500 com o objeto de erro público
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,31 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    // Teste: "GET para api/v1/status deve retornar 200"
+    test("Retrieving current system status", async () => {
+      // Faz uma requisição GET para a rota api/v1/status
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      // Espera que o status da resposta seja 200
+      expect(response.status).toBe(405);
+
+      // Converte a resposta para JSON
+      const responseBody = await response.json();
+
+      // Verifica se o corpo da resposta corresponde ao objeto de erro esperado
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError", // Nome do erro
+        message: "Método não permitido para este endpoint.", // Mensagem de erro
+        action:
+          "Verifique se o método HTTP enviado é valido para este endpoint.",
+        status_code: 405, // Código de status HTTP
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAlowedError` e `ServiceError`.
3. Faz o `InternalServerError` aceitar injeção do `statusCode`.